### PR TITLE
Use HTTPS instead of HTTP to actually load jQuery and don't get a Mixed-Content error

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
 </div>
 
 
-<script src="http://code.jquery.com/jquery-3.3.1.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
 
 </body>


### PR DESCRIPTION
jQuery fails to load in the homepage because of a `Mixed-Content` error:

![image](https://user-images.githubusercontent.com/38133098/71920693-0066a500-3190-11ea-9212-8fc0402168bd.png)

This fixes both errors.